### PR TITLE
Filter items that have every category in their keys

### DIFF
--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -603,7 +603,15 @@ Shuffle.prototype._doesPassFilter = function( category, $item ) {
     var keys = this.delimeter && !$.isArray( groups ) ?
         groups.split( this.delimeter ) :
         groups;
-    return $.inArray(category, keys) > -1;
+    var categories = [];
+    categories = categories.concat(category);
+    for (var i = 0; i < categories.length; i++) {
+      var categoryIsInKeys = $.inArray(categories[i], keys) > -1;
+      if(!categoryIsInKeys) {
+        return false;
+      }
+    }
+    return true;
   }
 };
 


### PR DESCRIPTION
This PR adds support for filtering the groups by more than 1 category.

if I had some groups as: 
```javascript
['all', 'main dishes', 'appetizers', 'desserts', 'vegetarian']
```
and I wanted to show only the vegetarian main dishes, I would have to make another group for that.

Now I can use 

```javascript
$grid.shuffle('shuffle', ['main dishes', 'vegetarian']);
```

and it will show only the vegetarian main dishes. The old format of 
```javascript
$grid.shuffle('shuffle', 'all');
```

 is still supported as well.