### PR TITLE
fix link to package.json

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -203,7 +203,7 @@ prism: true
     <div class="row">
       <div class="col-12@sm">
         <h2>Dependencies<a href="#dependencies"></a></h2>
-        <p>Shuffle's <a href="{{ site.baseurl }}/package.json">dependencies</a> are bundled with the dist file.</p>
+        <p>Shuffle's <a href="https://github.com/Vestride/Shuffle/blob/master/package.json">dependencies</a> are bundled with the dist file.</p>
         <p id="polyfills">Shuffle does, however, expect the following ES6/7 features: <code>Set</code>, <code>Array.from</code>, <code>Object.assign</code>, <code>Array.prototype.find</code>, and <code>Array.prototype.includes</code>. In order to support browsers like IE11 and Safari 8, <strong class="type--underline">you must include a polyfill</strong> for these features. You can use a service like <a href="https://polyfill.io">polyfill.io</a> to only load the polyfills that specific browser needs, or a polyfill script like <a href="https://www.npmjs.com/package/babel-polyfill">babel-polyfill</a> (which uses <code>core-js</code> internally).</p>
       </div>
     </div>


### PR DESCRIPTION
guess this should link to the package.json file on github? currently it results in a 404 when clicked from github pages