### PR TITLE
Fixed IE10 issue where the add() function did not work

### DIFF
--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -21,7 +21,19 @@ import arrayMax from './array-max';
 import hyphenate from './hyphenate';
 
 function arrayUnique(x) {
-  return Array.from(new Set(x));
+  var uniqueArray = Array.from(new Set(x));
+  if(x.length !== uniqueArray.length) {
+    //Handle issue in IE10 where
+    //Array.from() is unable to
+    //create a new array out of
+    //a Set object.
+    var newSet = new Set(x);
+    var uniqueArray = [];
+    newSet.forEach(function(item) {
+      uniqueArray.push(item);
+    })
+  }
+  return uniqueArray;
 }
 
 // Used for unique instance variables


### PR DESCRIPTION
When calling add() on an existing shuffle object, the Array.from() method in the uniqueArray function returns an empty array even though the parameter array is non-empty. This is due to an issue in IE10 where the Array.from() method does not work on Set objects. I was unable to find a better solution for IE10. Perhaps someone else can find a better solution.