### PR TITLE
Fix missing types when resolving from exports field in package.json

### DIFF
--- a/packages/shuffle/package.json
+++ b/packages/shuffle/package.json
@@ -18,6 +18,7 @@
   "module": "./dist/shuffle.esm.js",
   "source": "./src/shuffle.js",
   "exports": {
+    "types": "./index.d.ts",
     "require": "./dist/shuffle.js",
     "default": "./dist/shuffle.esm.js"
   },


### PR DESCRIPTION
ShuffleJs is missing Typescript types when using modern node export fields. This happens for example when using `moduleResolution: bunlder` in `tsconfig.json`

![image](https://github.com/Vestride/Shuffle/assets/2717384/f1436abe-7b71-44da-a92e-464c04c18f26)

This PR adds `types` to the `exports` declaration in `package.json`.

For more information about this, see here:

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing